### PR TITLE
Fix ListCommand::execute() must be of the type int

### DIFF
--- a/src/Core/Command/Branch/ProtectCommand.php
+++ b/src/Core/Command/Branch/ProtectCommand.php
@@ -119,6 +119,8 @@ class ProtectCommand extends AbstractCommand
         }
 
         $this->logger->notice(sprintf('Protected %d branches.', $updated));
+
+        return 0;
     }
 
     /**

--- a/src/Core/Command/Repo/ListCommand.php
+++ b/src/Core/Command/Repo/ListCommand.php
@@ -45,5 +45,7 @@ class ListCommand extends AbstractCommand
             ['Name', 'Full Name'],
             $items
         );
+
+        return 0;
     }
 }

--- a/src/Core/Command/Repo/SetDefaultBranchCommand.php
+++ b/src/Core/Command/Repo/SetDefaultBranchCommand.php
@@ -55,6 +55,8 @@ class SetDefaultBranchCommand extends AbstractCommand
         }
 
         $this->logger->notice(sprintf('Updated %d repositories.', $updated));
+
+        return 0;
     }
 
     /**

--- a/src/Core/Command/Repo/SetFeaturesCommand.php
+++ b/src/Core/Command/Repo/SetFeaturesCommand.php
@@ -73,6 +73,8 @@ class SetFeaturesCommand extends AbstractCommand
         }
 
         $this->logger->notice(sprintf('Updated %d repositories.', $updated));
+
+        return 0;
     }
 
     /**


### PR DESCRIPTION
Fatal error: Uncaught TypeError: Return value of "DigipolisGent\Github\Core\Command\Repo\ListCommand::execute()" must be of the type int, "null" returned. in /Volumes/webdev/www/digipolis/php_scripts_github/vendor/symfony/console/Command/Command.php on line 301

TypeError: Return value of "DigipolisGent\Github\Core\Command\Repo\ListCommand::execute()" must be of the type int, "null" returned. in /Volumes/webdev/www/digipolis/php_scripts_github/vendor/symfony/console/Command/Command.php on line 301

Call Stack:
    0.0022     394120   1. {main}() /Volumes/webdev/www/digipolis/php_scripts_github/bin/github:0
    0.0041     405088   2. require('/Volumes/webdev/www/digipolis/php_scripts_github/bin/github.php') /Volumes/webdev/www/digipolis/php_scripts_github/bin/github:5
    0.0488    2490440   3. DigipolisGent\Github\Application->run() /Volumes/webdev/www/digipolis/php_scripts_github/bin/github.php:49
    0.0749    2838504   4. DigipolisGent\Github\Application->doRun() /Volumes/webdev/www/digipolis/php_scripts_github/vendor/symfony/console/Application.php:171
    0.0776    2852360   5. DigipolisGent\Github\Application->doRunCommand() /Volumes/webdev/www/digipolis/php_scripts_github/vendor/symfony/console/Application.php:299
    0.0776    2852360   6. DigipolisGent\Github\Core\Command\Repo\ListCommand->run() /Volumes/webdev/www/digipolis/php_scripts_github/vendor/symfony/console/Application.php:1005